### PR TITLE
fix: button text not update in test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,16 +14,16 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install the Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-    - name: Install wasm-pack
-      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: actions/checkout@v4
+      - name: Install the Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-    - name: Run tests
-      run: cargo test --verbose
-    - run: wasm-pack test --headless --chrome
-    - run: wasm-pack test --headless --firefox
+      - name: Run tests
+        run: cargo test --verbose
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --firefox
 
   fmt:
     name: Rustfmt

--- a/src/components/main_button.rs
+++ b/src/components/main_button.rs
@@ -44,6 +44,7 @@ pub fn StartStopButton(
 #[cfg(test)]
 mod tests {
     use leptos::prelude::*;
+    use leptos::task::tick;
     use leptos::web_sys;
     use wasm_bindgen::JsCast;
     use wasm_bindgen_test::*;
@@ -54,7 +55,7 @@ mod tests {
 
     #[allow(dead_code)]
     #[wasm_bindgen_test]
-    fn test_click_button() {
+    async fn test_click_button() {
         // Arrange
         let document = document();
         let is_clicked_signal = signal(false);
@@ -71,13 +72,16 @@ mod tests {
             .unwrap()
             .unchecked_into::<web_sys::HtmlElement>();
 
+        // Assert
+        assert_eq!(btn.text_content().unwrap(), "START");
+
         // Act
         btn.click();
+        tick().await;
 
         // Assert
         assert!(is_clicked_signal.0.get_untracked());
         assert_eq!(btn_text_signal.0.get_untracked(), StartStopButtonText::Stop);
-        // FIXME:
-        // assert_eq!(btn.text_content().unwrap(), "STOP");
+        assert_eq!(btn.text_content().unwrap(), "STOP");
     }
 }


### PR DESCRIPTION
from leptos testing docs:
```rust

    // the reactive system is built on top of the async system, so
    // changes are not reflected
    // synchronously in the DOM
    // in order to detect the changes here, we'll just yield for a brief
    // time after each change,
    // allowing the effects that update the view to run
    tick().await;

```

closes https://github.com/edpyt/yapwir/issues/4